### PR TITLE
StreamDiffusionの対応とバリアント選択をconfing.iniに対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,25 @@ eraで遊ぶとプレイ内容をリアルタイムで画像生成する仕組�
  - Step 6～8
 3. hiresfix使用時は hiresfix step 0
 
+# [StreamDiffusion](https://github.com/cumulo-autumn/StreamDiffusion)対応による処理の超高速化
+
+### 対応環境の変更
+
+StreamDiffusionが対応しているPythonは3.10のため3.12のvenvは削除する
+
+[StreamDiffusion](https://github.com/cumulo-autumn/StreamDiffusion)の説明に従いTorchなどをインストール
+
+config.iniを変更
+
+```config.ini
+streamdiffusionで生成する = 1
+```
+
+プロンプトを再現する力はイマイチだが早い
+
+東方系統に強いスケベなSDXLモデルとか作らないと駄目かなこれは
+
+
 ### カスタマイズについて
 詳しくは別記
 

--- a/era2webui/era2webui.py
+++ b/era2webui/era2webui.py
@@ -1,23 +1,55 @@
-import os
 import asyncio
-import time
-import requests
-from watchdog.observers.polling import PollingObserver
-from watchdog.events import FileSystemEventHandler
-import json
-from sub import gen_Image
-from api import gen_Image_api
 import configparser
-from tkinter import filedialog
-# from eratohoYM.suberatohoYM import promptmaker
-from eraImascgpro.subcgpro import promptmaker
-from selenium import webdriver
+import os
 import sys
+import time
+from tkinter import filedialog
+
+from module.settings import Settings
+# バリアントの選択と設定
+#PromptMakerとCSVMFactoryはこれの変数使うからそれより前に呼ぶ
+#あとで直すなんか美しくない
+Settings.select_variant()
+
+import requests
+from module.api import gen_image_api
+from module.savedata_handler import SJHFactory
+from module.csv_manager import CSVMFactory
+from module.sub import gen_Image
+from selenium import webdriver
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers.polling import PollingObserver
+
+
+
+class PromptMakerFactory:
+    """class Setings にあるバリアントに従ってPromptMakerのインスタンスを作る
+    Returns:
+        _type_: _description_
+    """
+    @staticmethod
+    def create_prompt_maker(sjhandler):
+        variant = Settings.variant
+        if variant == 'eratohoYM':
+            from eratohoYM.suberatohoYM import PromptMakerYM
+            return PromptMakerYM(sjhandler)
+        elif variant == 'eraTW':
+            from eraTW.suberaTW import PromptMakerTW
+            return PromptMakerTW(sjhandler)
+        elif variant == 'eraImascgpro':
+            from eraImascgpro.subcgpro import PromptMakerImascgpro
+            return PromptMakerImascgpro(sjhandler)
 
 class FileHandler(FileSystemEventHandler):
+    """受け取る引数 order_queue は list
+
+    Args:
+        FileSystemEventHandler (_type_): _description_
+    """
     def __init__(self, queue):
         super().__init__()
         self.queue = queue
+
 
     # 作成と変更は同じ処理
     def on_created(self, event):
@@ -25,41 +57,52 @@ class FileHandler(FileSystemEventHandler):
     def on_modified(self, event):
         self.handle_event(event)
 
+
     def handle_event(self, event):
-        if not event.is_directory and event.src_path.endswith('.txt'):
-            self.txt_event(event)
+        if not event.is_directory:
+            if event.src_path.endswith('.txt'):
+                self.txt_event(event)
+            elif event.src_path.endswith('.csv'):
+                self.csv_event(event)
 
     def txt_event(self, event):
         # ファイルが作成されたらキューに追加する
         print("\ntxt検知")
 
         # 文字コードはeraの出力の時点でUTF-8(BOM付)にする。ERB中、SAVETEXTの第4引数を1にすればいい。
-        with open(event.src_path, 'r', encoding='utf-8_sig') as f:
-            try:
-                # ファイルをjsonとして読み込む
-                content = json.load(f)
-            except json.decoder.JSONDecodeError as e:
-                print("Error: Invalid JSON format(eraの出力がjsonフォーマットになってない) - ", e)
-                sys.exit()
+        save_path = event.src_path
+        # SaveJSONHandlerにファイル読み込みを委譲
+        self.save = SJHFactory.create_instance(save_path)
 
-            if len(self.queue) >= QUEUE_MAX_SIZE:
-                self.queue.pop(0)
-            self.queue.append((event.src_path, content))
+        if len(self.queue) >= QUEUE_MAX_SIZE:
+            self.queue.pop(0)
+        self.queue.append((event.src_path, self.save))
+
+    def csv_event(self, event):
+        # CSVファイルが更新されたときの処理
+        print("\nCSVファイル検知: " + event.src_path)
+
+        csvm = CSVMFactory.get_instance()
+        # CSVManagerにファイルの読み込みを委譲し、データフレームを更新
+        csv_name = os.path.basename(event.src_path)
+        csvm.process_csv_event(csv_name)
 
 
-def TaskExecutor(queue,driver):
+def TaskExecutor(order_queue,driver):
     while True:
-        if len(queue) > 0:
-            # キューからオーダーを取り出す
-            orders = queue.pop(0)
-            # ordersはjsonをloadした結果で辞書(dict)型だそうです。 なんで[1]なのかわからんけど下記の様に取り出せる。
-            # ---------ここがメインのオーダー処理--------------------------------------------------------------------------------------------------------
-            print("txtを読み込み シーン:" + str(orders[1]["scene"])) #読み込みチェック　シーンを書き出す
-            print("キャラ名:" + str(orders[1]["target"])) #キャラ名を書き出す
-            
-            
-            # プロンプト整形
-            prompt,negative,gen_width,gen_height = promptmaker(orders[1])
+        if order_queue:
+            # キューから一番古いオーダーを取り出す
+            file_path, sjhandler  = order_queue.pop(0)
+            # ordersはjsonをloadした結果で辞書(dict)型  [0]はpath､[1]が内容
+            # ---------ここがメインのオーダー処理-----------------------
+            # SaveJSONHandlerのインスタンスからJSONデータを取得
+            json_data = sjhandler.data  # JSONデータを別の変数に代入
+            print("txtを読み込み シーン:" + json_data["scene"]) #読み込みチェック　シーンを書き出す
+            print("キャラ名:" + json_data["target"]) #キャラ名を書き出す
+
+            # プロンプト整形 SaveJSONHandlerのメソッドを使うため  インスタンスそのもの  をわたす 依存性注入とかいうらしい
+            promptmaker = PromptMakerFactory.create_prompt_maker(sjhandler)
+            prompt,negative,gen_width,gen_height = promptmaker.generate_prompt()
 
             # add_prompt.txtの内容をpromptに追記する
             if add_prompt機能:
@@ -82,13 +125,17 @@ def TaskExecutor(queue,driver):
             # ブラウザ操作
             i = 1
             while True:
-                #driverを取得できない場合gen_Image_apiで生成する
+                #driverを取得できない場合gen_image_apiで生成する
                 if driver is None:
-                    status_code = asyncio.run(gen_Image_api(prompt, negative, gen_width, gen_height))
+                    stream = config_ini.get('Generater', 'StreamDiffusionで生成する', fallback='0') == '1'
+                    if stream == 1:
+                        status_code = image_generator.generate_image(prompt)
+                    else:
+                        status_code = asyncio.run(gen_image_api(prompt, negative, gen_width, gen_height))
                     if status_code == 200:
-                        time.sleep(1)
+                        time.sleep(0.1)
                         break #待機ゲージはapi.pyで処理する
-                
+
                 else:
                     if gen_Image(driver,prompt,negative,gen_width,gen_height) == True:
                         break
@@ -99,8 +146,8 @@ def TaskExecutor(queue,driver):
 
             print("\n完了")
             # 残りキューの表示
-            mark = " ☆" * len(queue)
-            print("未処理キュー:" + str(len(queue)) + mark)
+            mark = " ☆" * len(order_queue)
+            print("未処理キュー:" + str(len(order_queue)) + mark)
         else:
             # キューが空の場合は少し待つ
             time.sleep(0.02)
@@ -112,7 +159,7 @@ if __name__ == '__main__':
 
     # iniファイル読み込み
     config_ini = configparser.ConfigParser()
-    inipath = os.path.dirname(__file__) + "\config.ini"
+    inipath = os.path.abspath(os.path.join(os.path.dirname(__file__), "config.ini"))
     config_ini.read(inipath, 'UTF-8')
 
     # iniに項目がなかったら追加する
@@ -142,6 +189,10 @@ if __name__ == '__main__':
         config_ini.set('Generater', 'add_prompt機能', "1")
     if not 'apiモードで起動する' in config_ini['Generater']:
         config_ini.set('Generater', 'apiモードで起動する', "0")
+    if not 'StreamDiffusionで生成する' in config_ini['Generater']:
+        config_ini.set('Generater', 'StreamDiffusionで生成する', "0")
+    if not 'StreamDiffusionで生成する' in config_ini['Generater']:
+        config_ini.set('Generater', 'StreamDiffusionで生成する', "0")
 
     # ダイアログで監視対象フォルダを選ばせる。
     # ダイアログ表示はconfigファイルでスキップ設定可能
@@ -153,7 +204,7 @@ if __name__ == '__main__':
     else:
         # ダイアログを開く
         target_dir = filedialog.askdirectory(title = "監視するsavフォルダを選択",initialdir = dir)
-    
+
     # iniに記入
     config_ini.set("Paths", "erasav", target_dir)
     with open(inipath, "w", encoding='UTF-8') as configfile:
@@ -163,6 +214,25 @@ if __name__ == '__main__':
     if os.path.isdir(target_dir) == False:
         print("指定された監視フォルダ " + target_dir + " が見つかりません。終了します")
         sys.exit()
+
+    # CSVフォルダの処理
+    csv_dir = config_ini.get("Paths", "eracsv", fallback="")
+    skip_csv = int(config_ini.get("Generater", "csvフォルダの選択をスキップ", fallback=0))
+    if skip_csv and os.path.isdir(csv_dir):
+        csv_target_dir = csv_dir
+    else:
+        #Settings.variantで設定されたバリアントから監視するcsvフォルダのPathを作成
+        csv_target_dir = os.path.join(os.path.dirname(__file__), Settings.variant, 'csvfiles')
+    # iniにCSVパスを記入
+    config_ini.set("Paths", "eracsv", csv_target_dir)
+    with open(inipath, "w", encoding='UTF-8') as configfile:
+        config_ini.write(configfile)
+
+    # ダイアログを×で閉じたときの処理
+    if os.path.isdir(csv_target_dir) == False:
+        print("指定されたcsv監視フォルダ " + csv_target_dir + " が見つかりません。終了します")
+        sys.exit()
+
 
     # キューの最大サイズ
     QUEUE_MAX_SIZE = int(config_ini.get("Generater", "キューの最大サイズ", fallback=2))
@@ -175,6 +245,8 @@ if __name__ == '__main__':
     add_prompt機能 = int(config_ini.get("Generater", "add_prompt機能", fallback=0))
     # apiモードで起動する
     apiモードで起動する = int(config_ini.get("Generater", "apiモードで起動する", fallback=0))
+    # StreamDiffusionで生成する
+    StreamDiffusionで生成する = int(config_ini.get("Generater", "StreamDiffusionで生成する", fallback=0))
 
     # 画像ビューアの起動は手動にしました
 
@@ -193,7 +265,7 @@ if __name__ == '__main__':
             print("ブラウザを掴むのに失敗。chromeを-remote-debugging-port=9222オプションで開いておいてね")
             print(f"APIエラー詳細: {e}")
             return None
-    
+
 
     # APIの起動確認
     def check_api():
@@ -206,41 +278,55 @@ if __name__ == '__main__':
                 return e
 
 
-    # ブラウザが取得できなかった場合はAPIで動作 
-    print("Chromeへの接続を試行")
-    if not apiモードで起動する:
+    #StreamDiffusionモードかAPIモードで起動するかの設定をconfig.iniから取得
+    api_mode = config_ini.get('Generater', 'apiモードで起動する', fallback='0') == '1'
+    stream_mode = config_ini.get('Generater', 'StreamDiffusionで生成する', fallback='0') == '1'
+
+    # iniでAPIモードかStreamDiffusionの設定がある場合はブラウザのチェックを飛ばす
+    if not api_mode and not stream_mode:
+        print("Chromeへの接続を試行")
         driver = check_browser()
     else:
+        print("APIモードで起動")
         driver = None
-    
+
+    # ブラウザモードでの接続が成功したか、APIモードの処理
     if driver is not None:
         print("ブラウザモードで作動")
         print("取得したwebdriver:" + str(driver))
+    elif stream_mode:
+        print("StreamDiffusionモードで作動")
+        #モデル読み込みで時間がかかるのでStreamのときはここでインスタンスを用意する
+        from module.generate_stream import ImageGenerator
+        image_generator = ImageGenerator.get_instance()
+    elif stream_mode:
+        print("StreamDiffusionモードで作動")
+        #モデル読み込みで時間がかかるのでStreamのときはここでインスタンスを用意する
+        from module.generate_stream import ImageGenerator
+        image_generator = ImageGenerator.get_instance()
     else:
-        print("Chromeへの接続失敗。apiの試行")
+        print("APIの接続確認中")
         api_result = check_api()
         if api_result is True:
             print("API利用可能")
-            driver = None
         else:
-            print(f"APIの接続不能")
+            print("APIの接続不能")
             print("ブラウザ､APIともに使用不能")
             sys.exit()
-        
+
+
 
     # ファイル監視の開始
     file_handler = FileHandler(order_queue)
     observer = PollingObserver()
+    #各ファイルの監視を設定
     observer.schedule(file_handler, target_dir, recursive=False)
-    observer.start()
     print("txtファイルの監視を開始しました。target_dir:" + str(target_dir))
+    observer.schedule(file_handler, csv_target_dir, recursive=False)
+    print("csvファイルの監視を開始しました。csv_target_dir:" + str(csv_target_dir))
+
+    observer.start()
 
     # タスクの実行
     task_executor = TaskExecutor(order_queue,driver)
     task_executor.run(driver)
-
-    # ファイル監視の停止
-    observer.stop()
-    observer.join()
-    print("強制終了でしか終わらない現状、ここが処理されることはない")
-    driver.quit()

--- a/era2webui/module/generate_stream.py
+++ b/era2webui/module/generate_stream.py
@@ -1,0 +1,64 @@
+import torch
+import threading
+from diffusers import AutoencoderTiny, StableDiffusionPipeline
+from streamdiffusion import StreamDiffusion
+from streamdiffusion.image_utils import postprocess_image
+
+class ImageGenerator:
+    _instance = None
+
+    @classmethod #インスタンスがNoneでも動くために必要なデコレータ
+    def get_instance(cls):
+        """インスタンス作成メソッド
+        既存のインスタンスがあればそれを返す
+        これをやらないと生成ごとにモデルロードする
+        Returns:
+            _type_: _description_
+        """
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    def __init__(self):
+        # モデルと設定の初期化
+        self.pipe = StableDiffusionPipeline.from_pretrained("KBlueLeaf/kohaku-v2.1").to(
+            device=torch.device("cuda"),
+            dtype=torch.float16,
+        )
+
+        # Diffusers pipelineをStreamDiffusionにラップ
+        self.stream = StreamDiffusion(
+            self.pipe,
+            t_index_list=[0, 16, 32, 45],
+            torch_dtype=torch.float16,
+            cfg_type="none",
+        )
+
+        # モデルがLCMでなければマージする
+        self.stream.load_lcm_lora()
+        self.stream.fuse_lora()
+        # Tiny VAEで高速化
+        self.stream.vae = AutoencoderTiny.from_pretrained("madebyollin/taesd").to(
+            device=self.pipe.device, dtype=self.pipe.dtype
+        )
+        # xformersで高速化
+        self.pipe.enable_xformers_memory_efficient_attention()
+
+    def generate_image(self, prompt):
+        # streamを準備する
+        self.stream.prepare(prompt)
+
+        # Warmup >= len(t_index_list) x frame_buffer_size
+        for _ in range(4):
+            self.stream()
+
+        # 画像を生成して表示
+        x_output = self.stream.txt2img()
+        thread = threading.Thread(target=self.show_image, args=(x_output,))
+        thread.start()
+
+        return 200
+
+    def show_image(self, x_output):
+        image = postprocess_image(x_output, output_type="pil")[0]
+        image.show()

--- a/era2webui/module/settings.py
+++ b/era2webui/module/settings.py
@@ -1,20 +1,40 @@
+import configparser
+import os
+
+# iniファイル読み込み
+config_ini = configparser.ConfigParser()
+module_path = os.path.abspath(os.path.dirname(__file__))
+era2webui_path = os.path.abspath(os.path.dirname(module_path))
+inipath = os.path.join(era2webui_path, "config.ini")
+config_ini.read(inipath, 'UTF-8')
+
 class Settings:
     # バリアントの設定（初期値はNone）
     variant = None
 
     @classmethod
     def select_variant(cls):
-        # バリアント選択のロジック
-        print("バリアントを選択してください:")
-        print("1: eratohoYM")
-        print("2: eraTW")
-        print("3: eraImascgpro")
-        variant_number = input("選択: ")
+        Variant = config_ini.get("Variant", "Variant", fallback=0)
+        if not Variant:
+            # バリアント選択のロジック
+            print("バリアントを選択してください:")
+            print("1: eratohoYM")
+            print("2: eraTW")
+            print("3: eraImascgpro")
+            variant_number = input("選択: ")
 
-        # バリアント番号に応じてバリアント名を設定
-        if variant_number == '1':
-            cls.variant = 'eratohoYM'
-        elif variant_number == '2':
-            cls.variant = 'eraTW'
-        elif variant_number == '3':
-            cls.variant = 'eraImascgpro'
+            # バリアント番号に応じてバリアント名を設定
+            if variant_number == '1':
+                cls.variant = 'eratohoYM'
+            elif variant_number == '2':
+                cls.variant = 'eraTW'
+            elif variant_number == '3':
+                cls.variant = 'eraImascgpro'
+
+            # iniに記入
+            config_ini.set("Variant", "Variant", cls.variant)
+            with open(inipath, "w", encoding='UTF-8') as configfile:
+                config_ini.write(configfile)
+
+        else:
+            cls.variant = Variant


### PR DESCRIPTION
StreamDiffusionテスト実装､YMとか特に文字も読まずスキップ実行しての珠稼ぎ中でも生成が追いつく

とても楽しい


とりあえず実装なので､生成速度こそ早いがモデルが固定でトークン長も77制限があるので呪文に対して忠実とは言えない

生成後デフォルトの画像ブラウザが生成ごとにポップアップして表示され続けるので定期的に手動で閉じないとPCのリソースを専有し続けるので注意


バリアント選択はテストの都度選択があるのは面倒だったので､選択の表示はconfig.iniに記載が無い時のみ選択制に変更